### PR TITLE
Add config file for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: '2'
+jobs:
+  build:
+    working_directory: ~/build
+    docker:
+      - image: ptrteixeira:racket:6.9
+    steps:
+      - checkout
+      - raco test --table ~/build


### PR DESCRIPTION
Add the config file necessary to get this to work with CircleCI 2. I
know ahead of time that this build is going to fail tests (because there
are a block of tests that I never actually finished), and it may fail
during the checkout stage because git isn't installed on the image.
We'll see.