### PR TITLE
Fix image name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,4 @@ jobs:
       - image: ptrteixeira/racket:6.9
     steps:
       - checkout
-      - raco test --table ~/build
+      - run: raco test --table ~/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: ptrteixeira:racket:6.9
+      - image: ptrteixeira/racket:6.9
     steps:
       - checkout
       - raco test --table ~/build


### PR DESCRIPTION
Replace extra `:` with `/`, because apparently I don't know what docker images are.