### PR TITLE
Add Racket metadata file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,6 @@ jobs:
       - image: ptrteixeira/racket:6.9
     steps:
       - checkout
-      - run: raco pkg install --installation --auto --link ~/build
+      - run: raco pkg install --installation --auto --link --no-setup ~/build
+      - run: raco setup -D underload
       - run: raco test --table ~/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,5 @@ jobs:
       - image: ptrteixeira/racket:6.9
     steps:
       - checkout
+      - run: raco pkg install --installation --auto --link ~/build
       - run: raco test --table ~/build

--- a/info.rkt
+++ b/info.rkt
@@ -8,5 +8,6 @@
 
 (define deps '("base"
                "rackunit-lib"
+               ("megaparsack-lib" #:version "1.2.1")
                ("typed-racket-lib" #:version "1.7")))
 

--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,12 @@
+#lang info
+
+(define collection "underload")
+(define version "1.0.0")
+(define pkg-authors '(PtrTeixeira))
+(define pkg-desc 
+  "Interpreter for the Underload esoteric programming language")
+
+(define deps '("base"
+               "rackunit-lib"
+               ("typed-racket-lib" #:version "1.7")))
+


### PR DESCRIPTION
Add the metadata file (`info.rkt`) for Racket. The particular advantage
that this gives me is to specify dependencies. Currently I am only
relying on the deps that are always installed with Racket (at the
moment), but I will very shortly be adding dependencies on some other
libraries in order to write the parser more neatly.