### PR TITLE
Redefine tokens

### DIFF
--- a/tests.rkt
+++ b/tests.rkt
@@ -8,57 +8,69 @@
 (define tokenizer-tests
   (test-suite
    "Tokenizer Checking"
-   (check-pred list? (tokenize "") "Sanity check: Tokenizing the empty string gives a list")
-   (check-pred list? (tokenize "(hello):~*a^!S") "Sanity check: Tokenizing a non-empty string gives a list")
-   (check-exn #rx".*Unquoted \\[" (λ()(tokenize "([)")) "[ character must be escaped")
-   (check-exn #rx".*Unquoted \\]" (λ()(tokenize "(])")) "] character must be escaped")
-   (check-exn #rx".*Unquoted <" (λ()(tokenize "(<)")) "< character must be escaped")
-   (check-exn #rx".*Unquoted >" (λ()(tokenize "(>)")) "> character must be escaped")
-   (check-exn #rx".*Unrecognized character: q" (λ()(tokenize "q")) "non-commands should not be at the top level")
-   (check-not-exn (λ()(tokenize "(\"[\"]\"<\">\"\")")) "Escaped characters do not raise exceptions")
-   (check-equal? (tokenize "") '() "Tokenizing the empty string gives back an empty list")
+   (check-pred list? (tokenize "")
+               "Sanity check: Tokenizing the empty string gives a list")
+   (check-pred list? (tokenize "(hello):~*a^!S")
+               "Sanity check: Tokenizing a non-empty string gives a list")
+   (check-exn #rx".*Unquoted \\[" (λ()(tokenize "([)"))
+              "[ character must be escaped")
+   (check-exn #rx".*Unquoted \\]" (λ()(tokenize "(])"))
+              "] character must be escaped")
+   (check-exn #rx".*Unquoted <" (λ()(tokenize "(<)"))
+              "< character must be escaped")
+   (check-exn #rx".*Unquoted >" (λ()(tokenize "(>)"))
+              "> character must be escaped")
+   (check-exn #rx".*Unrecognized character: q" (λ()(tokenize "q"))
+              "non-commands should not be at the top level")
+   (check-not-exn (λ()(tokenize "(\"[\"]\"<\">\"\")"))
+                  "Escaped characters do not raise exceptions")
+   (check-equal? (tokenize "") '()
+                 "Tokenizing the empty string gives back an empty list")
    (check-equal? (tokenize "(hello):~a*^!S") 
-                 '("(hello)" ":" "~" "a" "*" "^" "!" "S") "Different commands are split into different tokens")
+                 `(,(push-token "hello")
+                   duplicate
+                   swap
+                   enclose
+                   concat
+                   eval
+                   drop
+                   print)
+                 "Different commands are split into different tokens")
    (check-equal? (tokenize "(he()o)")
-                 '("(he()o)") "Tokenizer permits nested parens")
+                 `(,(push-token "he()o"))
+                 "Tokenizer permits nested parens")
    (check-equal? (tokenize "(he)(l):(o)***S")
-                 '("(he)" "(l)" ":" "(o)" "*" "*" "*" "S")
+                 `(,(push-token "he")
+                   ,(push-token "l")
+                   duplicate
+                   ,(push-token "o")
+                   concat
+                   concat
+                   concat
+                   print)
                  "Different commands are split into different tokens")))
-
-
-(define classifier-tests 
-  (test-suite 
-   "Classifier Tests"
-   (check-equal? (classify "(hello)") 'push "Push token recognized")
-   (check-equal? (classify "*") 'concat "Concat token recognized")
-   (check-equal? (classify ":") 'duplicate "Duplicate token recognized")
-   (check-equal? (classify "~") 'swap "Swap token recognized")
-   (check-equal? (classify "a") 'enclose "Enclose token recognized")
-   (check-equal? (classify "^") 'eval "Eval token recognized")
-   (check-equal? (classify "!") 'drop "Drop token recognized")
-   (check-equal? (classify "S") 'print "Print token recognized")))
 
 (define helper-tests
   (test-suite 
    "Helper method tests"
-   (check-equal? (push (make-state '("(h)") '()))
-                 (make-state '() '("h")))
-   (check-equal? (push (make-state '("(h)" ":") '()))
-                 (make-state '(":") '("h")))
-   (check-equal? (duplicate (make-state '(":") '("h")))
+   (check-equal? (push (push-token "h") '() '())
+                 (state '() '("h")))
+   (check-equal? (push (push-token "h") '(duplicate) '())
+                 (make-state '(duplicate) '("h")))
+   (check-equal? (duplicate (make-state '(duplicate) '("h")))
                  (make-state '() '("h" "h")))
-   (check-equal? (swap (make-state '("~") '("a" "b")))
+   (check-equal? (swap (make-state '(swap) '("a" "b")))
                  (make-state '() '("b" "a")))
-   (check-equal? (concat (make-state '("*") '("b" "a")))
+   (check-equal? (concat (make-state '(concat) '("b" "a")))
                  (make-state '() '("ab")))
-   (check-equal? (enclose (make-state '("a" "S") '("x")))
-                 (make-state '("S") '("(x)")))
-   (check-equal? (eval (make-state '("^" "S") '(":" "l")))
-                 (make-state '(":" "S") '("l")))
-   (check-equal? (drop (make-state '("!") '("x")))
+   (check-equal? (enclose (make-state '(enclose print) '("x")))
+                 (make-state '(print) '("(x)")))
+   (check-equal? (eval (make-state '(eval print) '(":" "l")))
+                 (make-state '(duplicate print) '("l")))
+   (check-equal? (drop (make-state '(drop) '("x")))
                  (make-state '() '()))
    (let* ([output (open-output-string)]
-         [result (prints (make-state '("S") '("hello")) output)])
+         [result (prints (make-state '(print) '("hello")) output)])
      (check-equal? (get-output-string output) "hello")
      (check-equal? result (make-state '() '())))))
 
@@ -71,7 +83,16 @@
 
    (let* ([output (open-output-string)]
           [result (run (make-state
-                        '("(x)" "(he)" "(l)" ":" "(o)" "*" "*" "*" "~" "S")
+                        `(,(push-token "x")
+                          ,(push-token "he")
+                          ,(push-token "l")
+                          duplicate
+                          ,(push-token "o")
+                          concat
+                          concat
+                          concat
+                          swap
+                          print)
                         '()) output)])
      (check-equal? result '("hello")
                    "It returns everything left on the stack")
@@ -81,28 +102,27 @@
    ;; Using a builtin that requires something on the stack
    ;; without something on the stack fails
    (check-exn exn:fail? 
-              (λ()(run (make-state '("*") '())))
+              (λ()(run (make-state '(concat) '())))
               "Concatenating on an empty stack fails")
    (check-exn exn:fail?
-              (λ()(run (make-state '(":") '())))
+              (λ()(run (make-state '(duplicate) '())))
               "Duplicating on an empty stack fails")
    (check-exn exn:fail? 
-              (λ()(run (make-state '("!") '())))
+              (λ()(run (make-state '(drop) '())))
               "Dropping on an empty stack fails")
    (check-exn exn:fail? 
-              (λ()(run (make-state '("a") '())))
+              (λ()(run (make-state '(enclose) '())))
               "Enclosing on an empty stack fails")
    (check-exn exn:fail? 
-              (λ()(run (make-state '("~") '())))
+              (λ()(run (make-state '(swap) '())))
               "Swapping on an empty stack fails")
    (check-exn exn:fail? 
-              (λ()(run (make-state '("^") '())))
+              (λ()(run (make-state '(eval) '())))
               "Evaluating an empty stack fails")))
 
 (define all-tests
   (test-suite "Full Test Suite"
               tokenizer-tests
-              classifier-tests
               helper-tests
               runner-tests))
 


### PR DESCRIPTION
Previously I was passing things around in form of a string, which is a
very sub-par way of passing around information.  This changes tokens
from being strings (eg `":"`) to symbols (`'duplicate`), which has the
associated advantage of being their own types. Has an additional
advantage with push tokens, in that now I can deal with stripping parens
a little more nicely.