### PR TITLE
Bump some things in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: ptrteixeira/racket:6.9
+      - image: ptrteixeira/racket:6.12
     steps:
+      - run: apt-get update && apt-get install -y git sqlite
       - checkout
-      - run: raco pkg install --installation --auto --link --no-setup ~/build
-      - run: raco setup -D underload
+      - run: raco pkg install --deps search-auto --batch ~/build
       - run: raco test --table ~/build
+


### PR DESCRIPTION
* Upgrade from building on Racket 6.9 to building on 6.12
* Clean up what the installation system looks like. In particular goes through the installation process correctly, rather than manually running `raco setup` to work around some quirks in the install process 