### PR TITLE
Update Racket version from 6.12 -> 7.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: ptrteixeira/racket:6.12
+      - image: ptrteixeira/racket:7.3
     steps:
-      - run: apt-get update && apt-get install -y git sqlite
+      - run: apt-get update && apt-get install -y git sqlite3
       - checkout
       - run: raco pkg install --deps search-auto --batch ~/build
       - run: raco test --table ~/build


### PR DESCRIPTION
Update the version of Racket used in the build container from the rather old 6.12 to 7.3.